### PR TITLE
onBlurred fix

### DIFF
--- a/dist/fluid-labels.js
+++ b/dist/fluid-labels.js
@@ -40,7 +40,7 @@
         self.onFocused();
       });
       this.element.on('blur', function () {
-        self.blurred();
+        self.onBlurred();
       });
     }
   }

--- a/src/fluid-labels.js
+++ b/src/fluid-labels.js
@@ -40,7 +40,7 @@
         self.onFocused();
       });
       this.element.on('blur', function () {
-        self.blurred();
+        self.onBlurred();
       });
     }
   }


### PR DESCRIPTION
Line 43 of fluid-label.js was calling self.blurred() however blurred() doesn't exist which is throwing an error every time the field is changed. I changed the call to self.onBlurred() since this seems to be the correct function name. 
